### PR TITLE
Fix/user contract mapping

### DIFF
--- a/src/main/java/clutch/clutchserver/calculate/repository/CalculateRepository.java
+++ b/src/main/java/clutch/clutchserver/calculate/repository/CalculateRepository.java
@@ -12,4 +12,5 @@ public interface CalculateRepository extends JpaRepository<Calculate, Long> {
 
     List<Calculate> findAllByUser(User user);
 
+    Calculate findByUserId(Long userId);
 }

--- a/src/main/java/clutch/clutchserver/contract/controller/ContractController.java
+++ b/src/main/java/clutch/clutchserver/contract/controller/ContractController.java
@@ -51,7 +51,7 @@ public class ContractController {
             User user = user1.get();
 
             Contract contractEntity = null;
-            contractEntity = contractRepository.findByUser_Id(userId);
+            contractEntity = contractRepository.findByUserId(userId);
 
 
             if (contractEntity != null) {

--- a/src/main/java/clutch/clutchserver/contract/controller/ContractController.java
+++ b/src/main/java/clutch/clutchserver/contract/controller/ContractController.java
@@ -4,8 +4,10 @@ package clutch.clutchserver.contract.controller;
 import clutch.clutchserver.contract.S3.S3Service;
 import clutch.clutchserver.contract.dto.ContractRequestDto;
 import clutch.clutchserver.contract.entity.Contract;
+import clutch.clutchserver.contract.repository.ContractRepository;
 import clutch.clutchserver.contract.service.ContractService;
 import clutch.clutchserver.global.payload.ApiResponse;
+import clutch.clutchserver.image.entity.Image;
 import clutch.clutchserver.report.dto.ReportResponseDto;
 import clutch.clutchserver.user.entity.User;
 import clutch.clutchserver.user.repository.UserRepository;
@@ -34,6 +36,7 @@ public class ContractController {
     private final S3Service s3Service;
 
     private final UserRepository userRepository;
+    private final ContractRepository contractRepository;
 
     @PostMapping("/contract/{id}")
     @SecurityRequirement(name = "access-token")
@@ -43,10 +46,15 @@ public class ContractController {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             String useremail = authentication.getName();
 
-            Optional<User> user =userRepository.findByEmail(useremail);
-            Contract contract = user.get().getContract();
+            Optional<User> user1 =userRepository.findByEmail(useremail);
+            Long userId = user1.get().getId();
+            User user = user1.get();
 
-            if (contract != null) {
+            Contract contractEntity = null;
+            contractEntity = contractRepository.findByUser_Id(userId);
+
+
+            if (contractEntity != null) {
                 // 이미 계약이 있는 경우에 대한 로직 처리
                 // ...
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "계약이 이미 존재합니다.");

--- a/src/main/java/clutch/clutchserver/contract/entity/Contract.java
+++ b/src/main/java/clutch/clutchserver/contract/entity/Contract.java
@@ -3,6 +3,7 @@ package clutch.clutchserver.contract.entity;
 import clutch.clutchserver.building.entity.Building;
 import clutch.clutchserver.global.common.BaseDateEntity;
 import clutch.clutchserver.report.entity.Report;
+import clutch.clutchserver.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -34,6 +35,12 @@ public class Contract extends BaseDateEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "building_id")
     private Building building;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+
+
 
 }
 

--- a/src/main/java/clutch/clutchserver/contract/repository/ContractRepository.java
+++ b/src/main/java/clutch/clutchserver/contract/repository/ContractRepository.java
@@ -4,4 +4,5 @@ import clutch.clutchserver.contract.entity.Contract;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public  interface ContractRepository extends JpaRepository<Contract,Long> {
+    Contract findByUser_Id(Long userId);
 }

--- a/src/main/java/clutch/clutchserver/contract/repository/ContractRepository.java
+++ b/src/main/java/clutch/clutchserver/contract/repository/ContractRepository.java
@@ -4,5 +4,5 @@ import clutch.clutchserver.contract.entity.Contract;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public  interface ContractRepository extends JpaRepository<Contract,Long> {
-    Contract findByUser_Id(Long userId);
+    Contract findByUserId(Long userId);
 }

--- a/src/main/java/clutch/clutchserver/contract/service/ContractService.java
+++ b/src/main/java/clutch/clutchserver/contract/service/ContractService.java
@@ -40,7 +40,7 @@ public class ContractService {
 
 
 
-    public ResponseEntity<?> saveContract(ContractRequestDto requestDto, Long buildingId, Optional<User> user) throws IOException {
+    public ResponseEntity<?> saveContract(ContractRequestDto requestDto, Long buildingId, User user) throws IOException {
         // ContractRequestDto에서 필요한 데이터 추출
         Boolean hasLived = requestDto.getHas_lived();
         LocalDate transportReportDate = requestDto.getTransport_report_date();
@@ -65,6 +65,7 @@ public class ContractService {
                 .deposit(deposit)
                 .building(building)
                 // 여기에 필요한 데이터들 추가
+                .user(user)
                 .build();
 
 
@@ -72,12 +73,12 @@ public class ContractService {
         contractRepository.save(contract);
         ReportResponseDto response = createReportResponse(contract, building);
 
-        User userEntity =user.get();
-        if(userEntity.getContract()==null){
-            user.get().updateContract(contract);
-            userRepository.save(userEntity);
-        }
-        reportService.saveReport(userEntity.getId(),contract,building);
+        //User userEntity =user.get();
+        //if(userEntity.getContract()==null){
+        //    user.get().updateContract(contract);
+        //    userRepository.save(userEntity);
+        //}
+        reportService.saveReport(user.getId(),contract,building);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)

--- a/src/main/java/clutch/clutchserver/report/repository/ReportRepository.java
+++ b/src/main/java/clutch/clutchserver/report/repository/ReportRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    Optional<Report> findByContractId(Long contractId);
+    Report findByContractId(Long contractId);
 }

--- a/src/main/java/clutch/clutchserver/report/service/ReportService.java
+++ b/src/main/java/clutch/clutchserver/report/service/ReportService.java
@@ -63,8 +63,8 @@ public class ReportService {
 
     public ResponseEntity<?> getCompReport(String useremail) {
         User findUser = userRepository.findByEmail(useremail).get();
-        Contract findContract = findUser.getContract();
-        Report findReport = reportRepository.findByContractId(findContract.getId()).get();
+        Contract findContract = contractRepository.findByUserId(findUser.getId());
+        Report findReport = reportRepository.findByContractId(findContract.getId());
         Building findBuilding = findContract.getBuilding();
 
         ReportResponseDto reportResponseDto = ReportResponseDto.builder()
@@ -98,12 +98,11 @@ public class ReportService {
         // user의 email로 유저 찾기
         User findUser = userRepository.findByEmail(useremail).get();
 
-        // user와 연관된 계약 찾기
-        Contract findContract = findUser.getContract();
+        // userId로 연관된 계약 찾기
+        Contract findContract = contractRepository.findByUserId(findUser.getId());
 
-        // 계약id로 신고id 찾기
-        Long findReportId = reportRepository.findByContractId(findContract.getId()).get().getId();
-        Report findReport = reportRepository.findById(findReportId).get();
+        // 계약id로 신고 내역 찾기
+        Report findReport = reportRepository.findByContractId(findContract.getId());
 
         // report와 연관된 contract 삭제
         contractRepository.delete(findContract);

--- a/src/main/java/clutch/clutchserver/user/entity/User.java
+++ b/src/main/java/clutch/clutchserver/user/entity/User.java
@@ -35,15 +35,6 @@ public class User extends BaseDateEntity {
     @Nullable
     private String phoneNumber;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "contract_id")
-    private Contract contract;
-
-
-    // 업데이트 메서드
-    public void updateContract(Contract contract) {
-            this.contract =contract;
-    }
     public void updatePhoneNum(String phoneNumber) {
         this.phoneNumber = phoneNumber;
     }

--- a/src/main/java/clutch/clutchserver/user/service/UserService.java
+++ b/src/main/java/clutch/clutchserver/user/service/UserService.java
@@ -1,5 +1,7 @@
 package clutch.clutchserver.user.service;
 
+import clutch.clutchserver.calculate.entity.Calculate;
+import clutch.clutchserver.calculate.repository.CalculateRepository;
 import clutch.clutchserver.global.DefaultAssert;
 import clutch.clutchserver.global.common.enums.Reason;
 import clutch.clutchserver.global.payload.ApiResponse;
@@ -25,6 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final WithdrawalRepository withdrawalRepository;
     private final TokenRepository tokenRepository;
+    private final CalculateRepository calculateRepository;
 
     //유저 조회 (조회 기준 - 유저 email)
     public ResponseEntity<?> findUser(String useremail) {
@@ -60,6 +63,10 @@ public class UserService {
         Optional<Token> token = tokenRepository.findByUserId(user.get().getId());
         DefaultAssert.isTrue(token.isPresent(), "유저가 올바르지 않습니다.");
         tokenRepository.delete(token.get());
+
+        // user와 연관된 계산 내역 삭제
+        Calculate findCalculate = calculateRepository.findByUserId(user.get().getId());
+        calculateRepository.delete(findCalculate);
 
         // 탈퇴 사유 등록
         Withdrawal withdrawal = new Withdrawal();


### PR DESCRIPTION
User와 Report delete mapping시 발생하는 오류를 해결함
Report 삭제시 Contract를 같이, User 삭제시 Calculate를 같이 delete해주고
Contract에 User의 키 값을 넣어줌으로 Report를 삭제해도 User까지 건들지 않아도 되게 변경
